### PR TITLE
[FIX] 인증 실패 응답에서 LocalDateTime 직렬화 오류 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
-	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/chungnamthon/cheonon/global/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/chungnamthon/cheonon/global/security/CustomAuthenticationEntryPoint.java
@@ -4,22 +4,27 @@ import com.chungnamthon.cheonon.global.payload.ResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@RequiredArgsConstructor
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
+
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
 
-        ObjectMapper objectMapper = new ObjectMapper();
         String errorResponse = objectMapper.writeValueAsString(ResponseDto.of("인증이 필요합니다."));
         response.getWriter().write(errorResponse);
     }


### PR DESCRIPTION
- CustomAuthenticationEntryPoint에서 ObjectMapper를 직접 생성하지 않고 Spring에서 주입받도록 수정
- JacksonConfig의 JavaTimeModule 설정이 적용되도록 개선
- LocalDateTime 필드를 포함한 ResponseDto 직렬화 문제 해결

<!-- #이슈 번호를 매겨주세요 -->
- resolves #9 

---
### 📌 요약
- jackson 직렬화 문제 해결

### ✅ 작업 내용
- CustomAuthenticationEntryPoint에서 ObjectMapper를 직접 생성하지 않고 Spring에서 주입받도록 수정
- JacksonConfig의 JavaTimeModule 설정이 적용되도록 개선
- LocalDateTime 필드를 포함한 ResponseDto 직렬화 문제 해결

### 📚 참고 자료, 할 말
-
