### PR TITLE
[FIX] JWT 토큰 Bearer 누락 및 공백 대응을 위한 전처리 로직 추가

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/auth/jwt/JwtFilter.java
+++ b/src/main/java/com/chungnamthon/cheonon/auth/jwt/JwtFilter.java
@@ -43,10 +43,6 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private String resolveToken(HttpServletRequest request) {
         String bearer = request.getHeader("Authorization");
-        if (bearer != null && bearer.toLowerCase().startsWith("bearer ")) {
-            String token = bearer.replaceFirst("(?i)^Bearer\\s+", "").trim(); // 대소문자 무시 + 공백 정리
-            return token.isEmpty() ? null : token;
-        }
-        return null;
+        return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
     }
 }


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #28 

---
### 📌 요약
- Authorization 헤더에 `Bearer` 누락 또는 공백이 포함된 토큰 전달 시 발생하는 인증 예외를 방지하기 위해 JWT 전처리 로직을 추가했습니다.

### ✅ 작업 내용
- `JwtUtil`에 `preprocessToken()` 메서드 추가 (공백 제거 + Bearer 방어적 제거)
- `getUserIdFromToken`, `validateToken` 메서드에 전처리 적용
- 실수로 Bearer 없이 토큰이 전달되어도 인증되도록 처리

### 📚 참고 자료, 할 말
- 부족한 만큼 더 분발해서 에러 덜 뜨게 노력해보겠습니다..