### PR TITLE
[FEATOR] 카카오 소셜 로그인 기능 구현 및 리다이렉션 처리

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/global/config/SecurityConfig.java
+++ b/src/main/java/com/chungnamthon/cheonon/global/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.chungnamthon.cheonon.global.security.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -14,6 +15,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -38,8 +41,7 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
-                .formLogin(form -> form.disable())
-                .httpBasic(httpBasic -> httpBasic.disable())
+                .cors(cors -> {}) // cors 활성화만 하고 커스터마이징은 corsFilter()로 처리
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
@@ -48,8 +50,10 @@ public class SecurityConfig {
                                 "/api/auth/**",
                                 "/api/test-token/**",
                                 "/api/admin/merchants/fetch",
-                                "/api/auth/kakao/callback"
+                                "/api/auth/kakao/callback",
+                                "/error"
                         ).permitAll()
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex
@@ -64,9 +68,11 @@ public class SecurityConfig {
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
-
         config.setAllowCredentials(true);
-        config.addAllowedOriginPattern("*"); // 개발 중엔 *
+
+        // 🔸 프론트엔드 주소 명시 (필요시 여러 개 추가 가능)
+        config.setAllowedOrigins(List.of("http://localhost:3000", "https://2025-chungnamthon-team-5-fe.vercel.app"));
+
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");
 


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #43 

---
### 📌 요약
- 토큰 반환 방식을 기존 json-> 프론트엔드 주소로 리다이렉션 으로 변경 
- cors 설정에 프론트엔드 주소 추가

### ✅ 작업 내용
- 인가 코드 기반 accessToken, refreshToken 발급 및 프론트엔드로 리다이렉션 처리
- https://2025-chungnamthon-team-5-fe.vercel.app/callback 주소로 리다이렉트하며 쿼리 파라미터로 토큰 전달
- CORS 설정에 프론트 배포 도메인 추가하여 cross-origin 문제 해결

### 📚 참고 자료, 할 말
- 문제 발생시 언제든 연락주세용
