### PR TITLE
[REFACTOR] 카카오 소셜 로그인 연동 테스트를 위한 리다이렉션 코드 수정

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/chungnamthon/cheonon/auth/controller/KakaoAuthController.java
@@ -41,7 +41,7 @@ public class KakaoAuthController {
             TokenResponse tokenResponse = kakaoOauthService.kakaoLogin(code);
 
             String redirectUrl = UriComponentsBuilder
-                    .fromHttpUrl("https://2025-chungnamthon-team-5-fe.vercel.app/callback")
+                    .fromHttpUrl("http://localhost:5173/callback")
                     .queryParam("accessToken", tokenResponse.getAccessToken())
                     .queryParam("refreshToken", tokenResponse.getRefreshToken())
                     .build()


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #43 

---
### 📌 요약
-인가 url을 프론트 배포 서버에서 테스트 환경으로 수정

### ✅ 작업 내용
-인가 url을 프론트 배포 서버에서 테스트 환경으로 수정

### 📚 참고 자료, 할 말
- 테스트후 다시 원상 복구 하겠습니다
