### PR TITLE
[FEATURE] 홈 화면 제휴업체 조회 API 구현

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/home/controller/HomeController.java
+++ b/src/main/java/com/chungnamthon/cheonon/home/controller/HomeController.java
@@ -3,8 +3,12 @@ package com.chungnamthon.cheonon.home.controller;
 import com.chungnamthon.cheonon.global.payload.ResponseDto;
 import com.chungnamthon.cheonon.home.dto.HomeResponse;
 import com.chungnamthon.cheonon.home.service.HomeService;
+import com.chungnamthon.cheonon.map.dto.AffiliatePreviewResponse;
+import com.chungnamthon.cheonon.map.service.AffiliateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/home")
@@ -12,10 +16,19 @@ import org.springframework.web.bind.annotation.*;
 public class HomeController {
 
     private final HomeService homeService;
+    private final AffiliateService affiliateService;
 
+    // 🔹 홈 화면 정보 (모임 + 제휴업체 미리보기 등)
     @GetMapping
     public ResponseDto<HomeResponse> getHomeData() {
         HomeResponse response = homeService.getHomeData();
         return ResponseDto.of(response, "홈 화면 정보 불러오기 성공");
+    }
+
+    // 🔹 제휴업체 전체 조회 (상세용)
+    @GetMapping("/affiliate")
+    public ResponseDto<List<AffiliatePreviewResponse>> getAllAffiliates() {
+        List<AffiliatePreviewResponse> response = affiliateService.getAllAffiliates();
+        return ResponseDto.of(response, "제휴 업체 전체 목록 불러오기 성공");
     }
 }

--- a/src/main/java/com/chungnamthon/cheonon/home/dto/HomeResponse.java
+++ b/src/main/java/com/chungnamthon/cheonon/home/dto/HomeResponse.java
@@ -1,6 +1,7 @@
 package com.chungnamthon.cheonon.home.dto;
 
-import com.chungnamthon.cheonon.meeting.dto.response.MeetingPreviewDto;
+import com.chungnamthon.cheonon.meeting.dto.response.MeetingPreviewResponse;
+import com.chungnamthon.cheonon.map.dto.AffiliateHomePreviewResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,8 +11,9 @@ import java.util.List;
 @Builder
 public class HomeResponse {
 
-    private List<MeetingPreviewDto> recentMeetings;
-    // 이후 주석 처리해서 확장 준비
+    private List<MeetingPreviewResponse> recentMeetings;
+    private List<AffiliateHomePreviewResponse> topAffiliates;
+
+    // 이후 확장용 주석
     // private List<PowerUserDto> top5PowerUsers;
-    // private List<MerchantPreviewDto> top5Merchants;
 }

--- a/src/main/java/com/chungnamthon/cheonon/home/service/HomeService.java
+++ b/src/main/java/com/chungnamthon/cheonon/home/service/HomeService.java
@@ -1,7 +1,9 @@
 package com.chungnamthon.cheonon.home.service;
 
 import com.chungnamthon.cheonon.home.dto.HomeResponse;
-import com.chungnamthon.cheonon.meeting.dto.response.MeetingPreviewDto;
+import com.chungnamthon.cheonon.map.dto.AffiliateHomePreviewResponse;
+import com.chungnamthon.cheonon.map.service.AffiliateService;
+import com.chungnamthon.cheonon.meeting.dto.response.MeetingPreviewResponse;
 import com.chungnamthon.cheonon.meeting.repository.MeetingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,23 +17,32 @@ import java.util.List;
 public class HomeService {
 
     private final MeetingRepository meetingRepository;
+    private final AffiliateService affiliateService;
 
     public HomeResponse getHomeData() {
-        List<MeetingPreviewDto> recentMeetings;
+        List<MeetingPreviewResponse> recentMeetings;
         try {
             recentMeetings = meetingRepository.findTop3ByOrderByCreatedAtDesc()
                     .stream()
-                    .map(MeetingPreviewDto::from)
+                    .map(MeetingPreviewResponse::from)
                     .toList();
         } catch (Exception e) {
             log.error("홈화면 모임 데이터 조회 실패: {}", e.getMessage());
             recentMeetings = List.of();
         }
 
+        List<AffiliateHomePreviewResponse> topAffiliates;
+        try {
+            topAffiliates = affiliateService.getTop4Affiliates();
+        } catch (Exception e) {
+            log.error("홈화면 제휴업체 데이터 조회 실패: {}", e.getMessage());
+            topAffiliates = List.of();
+        }
+
         return HomeResponse.builder()
                 .recentMeetings(recentMeetings)
                 // .topUsers(null) // 추후 구현
-                // .sponsoredMerchants(null) // 추후 구현
+                .topAffiliates(topAffiliates)
                 .build();
     }
 }

--- a/src/main/java/com/chungnamthon/cheonon/map/dto/AffiliateHomePreviewResponse.java
+++ b/src/main/java/com/chungnamthon/cheonon/map/dto/AffiliateHomePreviewResponse.java
@@ -1,0 +1,17 @@
+package com.chungnamthon.cheonon.map.dto;
+
+import com.chungnamthon.cheonon.map.domain.Affiliate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AffiliateHomePreviewResponse {
+    private String name;
+
+    public static AffiliateHomePreviewResponse from(Affiliate a) {
+        return AffiliateHomePreviewResponse.builder()
+                .name(a.getName())
+                .build();
+    }
+}

--- a/src/main/java/com/chungnamthon/cheonon/map/dto/AffiliatePreviewResponse.java
+++ b/src/main/java/com/chungnamthon/cheonon/map/dto/AffiliatePreviewResponse.java
@@ -1,0 +1,21 @@
+package com.chungnamthon.cheonon.map.dto;
+
+import com.chungnamthon.cheonon.map.domain.Affiliate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AffiliatePreviewResponse {
+    private String name;
+    private String address;
+    private String tel;
+
+    public static AffiliatePreviewResponse from(Affiliate a) {
+        return AffiliatePreviewResponse.builder()
+                .name(a.getName())
+                .address(a.getAddress())
+                .tel(a.getTel())
+                .build();
+    }
+}

--- a/src/main/java/com/chungnamthon/cheonon/map/repository/AffiliateRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/map/repository/AffiliateRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AffiliateRepository extends JpaRepository<Affiliate, Long> {
+import java.util.List;
 
+public interface AffiliateRepository extends JpaRepository<Affiliate, Long> {
+    List<Affiliate> findTop3ByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/chungnamthon/cheonon/map/service/AffiliateService.java
+++ b/src/main/java/com/chungnamthon/cheonon/map/service/AffiliateService.java
@@ -2,13 +2,18 @@ package com.chungnamthon.cheonon.map.service;
 
 import com.chungnamthon.cheonon.map.domain.Affiliate;
 import com.chungnamthon.cheonon.map.dto.AffiliateDto;
+import com.chungnamthon.cheonon.map.dto.AffiliateHomePreviewResponse;
+import com.chungnamthon.cheonon.map.dto.AffiliatePreviewResponse;
 import com.chungnamthon.cheonon.map.repository.AffiliateRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -47,5 +52,23 @@ public class AffiliateService {
                 .createAt(a.getCreatedAt())
                 .updateAt(a.getUpdatedAt())
                 .build();
+    }
+
+    private final AffiliateRepository affiliateRepository;
+
+    // 홈 화면용 간단 정보 (이름만)
+    public List<AffiliateHomePreviewResponse> getTop4Affiliates() {
+        return affiliateRepository.findAll(PageRequest.of(0, 4))
+                .stream()
+                .map(AffiliateHomePreviewResponse::from)
+                .toList();
+    }
+
+    // 제휴 업체 전체 목록 or 상세용
+    public List<AffiliatePreviewResponse> getAllAffiliates() {
+        return affiliateRepository.findAll()
+                .stream()
+                .map(AffiliatePreviewResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/chungnamthon/cheonon/meeting/dto/response/MeetingPreviewResponse.java
+++ b/src/main/java/com/chungnamthon/cheonon/meeting/dto/response/MeetingPreviewResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class MeetingPreviewDto {
+public class MeetingPreviewResponse {
 
     private Long id;
     private String title;
@@ -14,8 +14,8 @@ public class MeetingPreviewDto {
     private String location; // Enum을 문자열로
     private String schedule; // Enum을 문자열로
 
-    public static MeetingPreviewDto from(Meeting meeting) {
-        return MeetingPreviewDto.builder()
+    public static MeetingPreviewResponse from(Meeting meeting) {
+        return MeetingPreviewResponse.builder()
                 .id(meeting.getId())
                 .title(meeting.getTitle())
                 .imageUrl(meeting.getImageUrl())


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #42 
---
### 📌 요약
- 홈 화면에서 사용한 제휴업체 home api 구현

### ✅ 작업 내용
- 홈 화면에서 사용할 최근 생성된 제휴업체 4개 조회 기능 추가
- 홈화면에서 더 자세한 정보를 제공하는 이번주 제휴업체 api 구현
- HomeService, HomeController 수정
- 공용 ResponseDto를 활용해 응답 포맷 통일

### 📚 참고 자료, 할 말
- 포인트 파트 구현 완료되는대로 파워유저도 추가하겠습니다
