### PR TITLE
[FEATURE] 파워유저 기능 전체 구현 (스케줄러, 저장, 조회 API 포함)

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/global/config/SchedulerConfig.java
+++ b/src/main/java/com/chungnamthon/cheonon/global/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.chungnamthon.cheonon.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/chungnamthon/cheonon/home/dto/HomeResponse.java
+++ b/src/main/java/com/chungnamthon/cheonon/home/dto/HomeResponse.java
@@ -2,6 +2,7 @@ package com.chungnamthon.cheonon.home.dto;
 
 import com.chungnamthon.cheonon.meeting.dto.response.MeetingPreviewResponse;
 import com.chungnamthon.cheonon.map.dto.AffiliateHomePreviewResponse;
+import com.chungnamthon.cheonon.point.dto.response.PowerUserResponse;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,7 +14,5 @@ public class HomeResponse {
 
     private List<MeetingPreviewResponse> recentMeetings;
     private List<AffiliateHomePreviewResponse> topAffiliates;
-
-    // 이후 확장용 주석
-    // private List<PowerUserDto> top5PowerUsers;
+    private List<PowerUserResponse> powerUsers;
 }

--- a/src/main/java/com/chungnamthon/cheonon/home/service/HomeService.java
+++ b/src/main/java/com/chungnamthon/cheonon/home/service/HomeService.java
@@ -5,6 +5,8 @@ import com.chungnamthon.cheonon.map.dto.AffiliateHomePreviewResponse;
 import com.chungnamthon.cheonon.map.service.AffiliateService;
 import com.chungnamthon.cheonon.meeting.dto.response.MeetingPreviewResponse;
 import com.chungnamthon.cheonon.meeting.repository.MeetingRepository;
+import com.chungnamthon.cheonon.point.dto.response.PowerUserResponse;
+import com.chungnamthon.cheonon.point.service.PowerUserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ public class HomeService {
 
     private final MeetingRepository meetingRepository;
     private final AffiliateService affiliateService;
+    private final PowerUserService powerUserService; // ✅ 추가된 부분
 
     public HomeResponse getHomeData() {
         List<MeetingPreviewResponse> recentMeetings;
@@ -39,10 +42,18 @@ public class HomeService {
             topAffiliates = List.of();
         }
 
+        List<PowerUserResponse> topPowerUsers;
+        try {
+            topPowerUsers = powerUserService.getRecentPowerUsers();
+        } catch (Exception e) {
+            log.error("홈화면 파워유저 데이터 조회 실패: {}", e.getMessage());
+            topPowerUsers = List.of();
+        }
+
         return HomeResponse.builder()
                 .recentMeetings(recentMeetings)
-                // .topUsers(null) // 추후 구현
                 .topAffiliates(topAffiliates)
+                .powerUsers(topPowerUsers)
                 .build();
     }
 }

--- a/src/main/java/com/chungnamthon/cheonon/point/domain/PowerUser.java
+++ b/src/main/java/com/chungnamthon/cheonon/point/domain/PowerUser.java
@@ -1,0 +1,43 @@
+package com.chungnamthon.cheonon.point.domain;
+
+import com.chungnamthon.cheonon.global.domain.BaseEntity;
+import com.chungnamthon.cheonon.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@Table(name = "power_user")
+public class PowerUser extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "total_point")
+    private Integer totalPoint;
+
+    @Column(name = "'rank'")
+    private Integer rank;
+
+    @Column(name = "week_of")
+    private LocalDate weekOf; // 예: 2025-07-22 기준이면 7월 22일 포함된 주의 월요일
+
+    @Builder
+    public PowerUser(User user, Integer totalPoint, Integer rank, LocalDate weekOf) {
+        this.user = user;
+        this.totalPoint = totalPoint;
+        this.rank = rank;
+        this.weekOf = weekOf;
+    }
+
+    public void setRank(int rank) {
+        this.rank = rank;
+    }
+
+    protected PowerUser() {
+    }
+}

--- a/src/main/java/com/chungnamthon/cheonon/point/dto/response/PowerUserResponse.java
+++ b/src/main/java/com/chungnamthon/cheonon/point/dto/response/PowerUserResponse.java
@@ -1,0 +1,26 @@
+package com.chungnamthon.cheonon.point.dto.response;
+
+import com.chungnamthon.cheonon.point.domain.PowerUser;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PowerUserResponse {
+
+    private Long userId;
+    private String nickname;
+    private String image;
+    private Integer totalPoint;
+    private Integer rank;
+
+    public static PowerUserResponse from(PowerUser powerUser) {
+        return PowerUserResponse.builder()
+                .userId(powerUser.getUser().getId())
+                .nickname(powerUser.getUser().getNickname())
+                .image(powerUser.getUser().getImage())
+                .totalPoint(powerUser.getTotalPoint())
+                .rank(powerUser.getRank())
+                .build();
+    }
+}

--- a/src/main/java/com/chungnamthon/cheonon/point/repository/PointRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/point/repository/PointRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
@@ -14,4 +17,12 @@ public interface PointRepository extends JpaRepository<Point, Long> {
 
     @Query("SELECT COALESCE(SUM(p.changedPoint), 0) FROM Point p WHERE p.user.id = :userId")
     int sumPointByUserId(@Param("userId") Long userId);
+
+    @Query("""
+    SELECT p.user.id, SUM(p.changedPoint)
+    FROM Point p
+    GROUP BY p.user.id
+    ORDER BY SUM(p.changedPoint) DESC
+""")
+    List<Object[]> findTopUsersByTotalPoint(Pageable pageable);
 }

--- a/src/main/java/com/chungnamthon/cheonon/point/repository/PowerUserRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/point/repository/PowerUserRepository.java
@@ -1,0 +1,14 @@
+package com.chungnamthon.cheonon.point.repository;
+
+import com.chungnamthon.cheonon.point.domain.PowerUser;
+import lombok.Builder;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Repository
+public interface PowerUserRepository extends JpaRepository<PowerUser, Long> {
+    List<PowerUser> findTop5ByWeekOfOrderByRankAsc(LocalDate weekOf);
+}

--- a/src/main/java/com/chungnamthon/cheonon/point/scheduler/PowerUserScheduler.java
+++ b/src/main/java/com/chungnamthon/cheonon/point/scheduler/PowerUserScheduler.java
@@ -1,0 +1,25 @@
+package com.chungnamthon.cheonon.point.scheduler;
+
+import com.chungnamthon.cheonon.point.service.PowerUserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PowerUserScheduler {
+
+    private final PowerUserService powerUserService;
+
+    /**
+     * 매주 월요일 새벽 3시 파워유저 갱신
+     */
+    @Scheduled(cron = "0 0 3 * * MON", zone = "Asia/Seoul")
+    public void update() {
+        log.info("🕒 파워유저 스케줄 시작");
+        powerUserService.updateWeeklyTopUsers();
+        log.info("✅ 파워유저 스케줄 종료");
+    }
+}

--- a/src/main/java/com/chungnamthon/cheonon/point/service/PowerUserService.java
+++ b/src/main/java/com/chungnamthon/cheonon/point/service/PowerUserService.java
@@ -1,0 +1,58 @@
+package com.chungnamthon.cheonon.point.service;
+
+import com.chungnamthon.cheonon.point.domain.PowerUser;
+import com.chungnamthon.cheonon.point.dto.response.PowerUserResponse;
+import com.chungnamthon.cheonon.point.repository.PointRepository;
+import com.chungnamthon.cheonon.point.repository.PowerUserRepository;
+import com.chungnamthon.cheonon.user.domain.User;
+import com.chungnamthon.cheonon.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class PowerUserService {
+
+    private final PointRepository pointRepository;
+    private final PowerUserRepository powerUserRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void updateWeeklyTopUsers() {
+        LocalDate thisWeekMonday = LocalDate.now().with(DayOfWeek.MONDAY); // 기준 주
+
+        List<Object[]> topUsers = pointRepository.findTopUsersByTotalPoint(PageRequest.of(0, 5));
+        Set<Long> seenUserIds = new HashSet<>();
+        int rank = 1;
+
+        for (Object[] row : topUsers) {
+            Long userId = (Long) row[0];
+            if (seenUserIds.contains(userId)) continue;
+
+            Integer totalPoint = ((Number) row[1]).intValue();
+            User user = userRepository.findById(userId).orElseThrow();
+
+            PowerUser powerUser = new PowerUser(user, totalPoint, rank++, thisWeekMonday); // ← ✅ 여기에 주차 정보 포함
+            powerUserRepository.save(powerUser);
+
+            seenUserIds.add(userId);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<PowerUserResponse> getRecentPowerUsers() {
+        LocalDate thisWeek = LocalDate.now().with(DayOfWeek.MONDAY); // 이번 주 월요일
+        return powerUserRepository.findTop5ByWeekOfOrderByRankAsc(thisWeek)
+                .stream()
+                .map(PowerUserResponse::from)
+                .toList();
+    }
+}


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #42 
---
### 📌 요약
- 매주 월요일 03시에 포인트 상위 유저 5명을 저장
- 메인페이지 전체 구현 완료 

### ✅ 작업 내용
- 매주 월요일 03시에 포인트 상위 유저 5명을 PowerUser로 저장하는 스케줄러 구현
- PowerUser 엔티티에 rank, totalPoint, weekOf 컬럼 정의
- 조회 시 이번 주 월요일 기준의 상위 5명만 응답하는 서비스 및 API 구성
- 홈 화면에 사용될 DTO PowerUserResponse 구성
- 중복 저장 방지를 위한 userId 필터링 및 rank 처리 로직 포함

### 📚 참고 자료, 할 말
- 마지막까지 화이팅해용!!
