### PR TITLE
[FIX] 마이페이지 쿠폰/포인트 조회 오류 수정

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/coupon/repository/CouponUserRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/coupon/repository/CouponUserRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface CouponUserRepository extends JpaRepository<CouponUser, Long> {
     List<CouponUser> findByUserId(Long userId);
 
-    int countByUserId(Long userId);
+    int countByUser_Id(Long userId);
 }

--- a/src/main/java/com/chungnamthon/cheonon/mypage/service/MyPageService.java
+++ b/src/main/java/com/chungnamthon/cheonon/mypage/service/MyPageService.java
@@ -21,7 +21,7 @@ public class MyPageService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다."));
 
         int currentPoint = pointRepository.sumPointByUserId(userId); // 총 포인트 (ex. +2000 -300 등 계산된 결과)
-        int couponCount = couponUserRepository.countByUserId(userId); // 유저가 보유한 쿠폰 개수
+        int couponCount = couponUserRepository.countByUser_Id(userId); // 유저가 보유한 쿠폰 개수
 
         return MyPageResponse.builder()
                 .userId(user.getId())


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #70 
---
### 📌 요약
- 마이페이지 쿠폰/포인트 조회 오류 수정

### ✅ 작업 내용
- CouponUserRepository 메서드 네이밍 오류(countByUserId → countByUser_Id) 수정
- 포인트, 쿠폰 수가 0으로 조회되던 문제 해결
- MyPageService에서 조회 로직 정상화

### 📚 참고 자료, 할 말
- 오류가 발생하면 언제든 연락 주세요
