### PR TITLE
[FIX] 내 쿠폰 리스트에서 사용한 쿠폰도 보이는 문제 해결

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/coupon/repository/CouponUserRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/coupon/repository/CouponUserRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CouponUserRepository extends JpaRepository<CouponUser, Long> {
-    List<CouponUser> findByUserId(Long userId);
+    List<CouponUser> findByUserIdAndIsUsedFalse(Long userId);
 
     int countByUser_Id(Long userId);
 

--- a/src/main/java/com/chungnamthon/cheonon/coupon/service/CouponService.java
+++ b/src/main/java/com/chungnamthon/cheonon/coupon/service/CouponService.java
@@ -142,7 +142,7 @@ public class CouponService {
 
     public List<MyCouponListResponse> getMyCouponList(String token) {
         Long userId = jwtUtil.getUserIdFromToken(token);
-        List<CouponUser> myCoupons = couponUserRepository.findByUserId(userId);
+        List<CouponUser> myCoupons = couponUserRepository.findByUserIdAndIsUsedFalse(userId);
 
         List<Coupon> coupons = new ArrayList<>();
         for (CouponUser myCoupon : myCoupons) {


### PR DESCRIPTION
- isUsed가 true인 쿠폰 미포함

<!-- #이슈 번호를 매겨주세요 -->
- resolves #98
---
### 📌 요약
- 내 쿠폰 리스트에서 사용한 쿠폰도 보이는 문제 해결

### ✅ 작업 내용
- `isUsed`가 `true`인 쿠폰은 응답 리스트에 포함히지 않도록 수정했습니다.

### 📚 참고 자료, 할 말
-
