### PR TITLE
[REFACTOR] 로그아웃 구조 개선

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/auth/controller/TokenController.java
+++ b/src/main/java/com/chungnamthon/cheonon/auth/controller/TokenController.java
@@ -6,6 +6,7 @@ import com.chungnamthon.cheonon.auth.service.AuthService;
 import com.chungnamthon.cheonon.global.payload.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import com.chungnamthon.cheonon.auth.jwt.JwtUtil;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 public class TokenController {
 
     private final AuthService authService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/refresh")
     public ResponseDto<TokenResponse> refresh(@RequestBody RefreshTokenRequest requestDto) {
@@ -21,8 +23,9 @@ public class TokenController {
     }
 
     @PostMapping("/logout")
-    public ResponseDto<String> logout(@RequestBody RefreshTokenRequest requestDto) {
-        authService.logout(requestDto.getRefreshToken());
+    public ResponseDto<String> logout(@RequestHeader("Authorization") String authorizationHeader) {
+        String refreshToken = jwtUtil.preprocessToken(authorizationHeader);
+        authService.logout(refreshToken);
         return ResponseDto.of("Successfully logged out");
     }
 }

--- a/src/main/java/com/chungnamthon/cheonon/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/chungnamthon/cheonon/auth/jwt/JwtUtil.java
@@ -109,7 +109,7 @@ public class JwtUtil {
     }
 
     // ✅ 토큰 전처리 메서드 추가
-    private String preprocessToken(String token) {
+    public String preprocessToken(String token) {
         if (token == null) {
             throw new IllegalArgumentException("JWT token cannot be null");
         }


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #102 

### 📌 요약
-  기존에 request body에서 받던 리프레쉬 토큰을 헤더로 받게 구조 변경

### ✅ 작업 내용
- TokenController에서 JwtUtil 인스턴스 주입 방식으로 변경
- 로그아웃 시 refresh token을 Authorization 헤더에서 추출하도록 수정

### 📚 참고 자료, 할 말
- 연동중 문제가 생기면 언제든 연락주세요
