### PR TITLE
[REFACTOR] 기존의 'rank' -> ranking으로 컬럼명 수정

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/poweruser/PowerUserRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/poweruser/PowerUserRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 @Repository
 public interface PowerUserRepository extends JpaRepository<PowerUser, Long> {
-    List<PowerUser> findTop5ByWeekOfOrderByRankAsc(LocalDate weekOf);
+    List<PowerUser> findTop5ByWeekOfOrderByRankingAsc(LocalDate weekOf);
 }

--- a/src/main/java/com/chungnamthon/cheonon/poweruser/domain/PowerUser.java
+++ b/src/main/java/com/chungnamthon/cheonon/poweruser/domain/PowerUser.java
@@ -20,8 +20,8 @@ public class PowerUser extends BaseEntity {
     @Column(name = "total_point")
     private Integer totalPoint;
 
-    @Column(name = "'rank'")
-    private Integer rank;
+    @Column(name = "ranking")
+    private Integer ranking;
 
     @Column(name = "week_of")
     private LocalDate weekOf; // 예: 2025-07-22 기준이면 7월 22일 포함된 주의 월요일
@@ -30,12 +30,12 @@ public class PowerUser extends BaseEntity {
     public PowerUser(User user, Integer totalPoint, Integer rank, LocalDate weekOf) {
         this.user = user;
         this.totalPoint = totalPoint;
-        this.rank = rank;
+        this.ranking = ranking;
         this.weekOf = weekOf;
     }
 
-    public void setRank(int rank) {
-        this.rank = rank;
+    public void setRank(int ranking) {
+        this.ranking = ranking;
     }
 
     protected PowerUser() {

--- a/src/main/java/com/chungnamthon/cheonon/poweruser/dto/PowerUserResponse.java
+++ b/src/main/java/com/chungnamthon/cheonon/poweruser/dto/PowerUserResponse.java
@@ -12,7 +12,7 @@ public class PowerUserResponse {
     private String nickname;
     private String image;
     private Integer totalPoint;
-    private Integer rank;
+    private Integer ranking;
 
     public static PowerUserResponse from(PowerUser powerUser) {
         return PowerUserResponse.builder()
@@ -20,7 +20,7 @@ public class PowerUserResponse {
                 .nickname(powerUser.getUser().getNickname())
                 .image(powerUser.getUser().getImage())
                 .totalPoint(powerUser.getTotalPoint())
-                .rank(powerUser.getRank())
+                .ranking(powerUser.getRanking())
                 .build();
     }
 }

--- a/src/main/java/com/chungnamthon/cheonon/poweruser/service/PowerUserService.java
+++ b/src/main/java/com/chungnamthon/cheonon/poweruser/service/PowerUserService.java
@@ -50,7 +50,7 @@ public class PowerUserService {
     @Transactional(readOnly = true)
     public List<PowerUserResponse> getRecentPowerUsers() {
         LocalDate thisWeek = LocalDate.now().with(DayOfWeek.MONDAY); // 이번 주 월요일
-        return powerUserRepository.findTop5ByWeekOfOrderByRankAsc(thisWeek)
+        return powerUserRepository.findTop5ByWeekOfOrderByRankingAsc(thisWeek)
                 .stream()
                 .map(PowerUserResponse::from)
                 .toList();


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #106 
---
### 📌 요약
- 파워유저 도메인 전체에서 

### ✅ 작업 내용
- poweruser 전반에서 'rank' -> ranking으로 컬럼명 수정

### 📚 참고 자료, 할 말
- 연동중 문제가 생기면 연락주세요 
