### PR TITLE
[REFACTOR] 로그인 + jwt 예외처리 로직 수정

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/auth/controller/TokenController.java
+++ b/src/main/java/com/chungnamthon/cheonon/auth/controller/TokenController.java
@@ -3,6 +3,8 @@ package com.chungnamthon.cheonon.auth.controller;
 import com.chungnamthon.cheonon.auth.dto.request.RefreshTokenRequest;
 import com.chungnamthon.cheonon.auth.dto.response.TokenResponse;
 import com.chungnamthon.cheonon.auth.service.AuthService;
+import com.chungnamthon.cheonon.global.exception.BusinessException;
+import com.chungnamthon.cheonon.global.exception.error.AuthenticationError;
 import com.chungnamthon.cheonon.global.payload.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +25,10 @@ public class TokenController {
     }
 
     @PostMapping("/logout")
-    public ResponseDto<String> logout(@RequestHeader("Authorization") String authorizationHeader) {
+    public ResponseDto<String> logout(@RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
+        if (authorizationHeader == null || authorizationHeader.isBlank()) {
+            throw new BusinessException(AuthenticationError.INVALID_REFRESH_TOKEN); // or CommonError.MISSING_HEADER
+        }
         String refreshToken = jwtUtil.preprocessToken(authorizationHeader);
         authService.logout(refreshToken);
         return ResponseDto.of("Successfully logged out");

--- a/src/main/java/com/chungnamthon/cheonon/home/service/HomeService.java
+++ b/src/main/java/com/chungnamthon/cheonon/home/service/HomeService.java
@@ -20,40 +20,43 @@ public class HomeService {
 
     private final MeetingRepository meetingRepository;
     private final AffiliateService affiliateService;
-    private final PowerUserService powerUserService; // ✅ 추가된 부분
+    private final PowerUserService powerUserService;
 
     public HomeResponse getHomeData() {
-        List<MeetingPreviewResponse> recentMeetings;
+        return HomeResponse.builder()
+                .recentMeetings(getRecentMeetingsSafely())
+                .topAffiliates(getAffiliatesSafely())
+                .powerUsers(getPowerUsersSafely())
+                .build();
+    }
+
+    private List<MeetingPreviewResponse> getRecentMeetingsSafely() {
         try {
-            recentMeetings = meetingRepository.findTop3ByOrderByCreatedAtDesc()
+            return meetingRepository.findTop3ByOrderByCreatedAtDesc()
                     .stream()
                     .map(MeetingPreviewResponse::from)
                     .toList();
         } catch (Exception e) {
-            log.error("홈화면 모임 데이터 조회 실패: {}", e.getMessage());
-            recentMeetings = List.of();
+            log.error("❗ [Home] 모임 데이터 조회 실패", e);
+            return List.of();
         }
+    }
 
-        List<AffiliateHomePreviewResponse> topAffiliates;
+    private List<AffiliateHomePreviewResponse> getAffiliatesSafely() {
         try {
-            topAffiliates = affiliateService.getAffiliateList();
+            return affiliateService.getAffiliateList();
         } catch (Exception e) {
-            log.error("홈화면 제휴업체 데이터 조회 실패: {}", e.getMessage());
-            topAffiliates = List.of();
+            log.error("❗ [Home] 제휴업체 데이터 조회 실패", e);
+            return List.of();
         }
+    }
 
-        List<PowerUserResponse> topPowerUsers;
+    private List<PowerUserResponse> getPowerUsersSafely() {
         try {
-            topPowerUsers = powerUserService.getRecentPowerUsers();
+            return powerUserService.getRecentPowerUsers();
         } catch (Exception e) {
-            log.error("홈화면 파워유저 데이터 조회 실패: {}", e.getMessage());
-            topPowerUsers = List.of();
+            log.error("❗ [Home] 파워유저 데이터 조회 실패", e);
+            return List.of();
         }
-
-        return HomeResponse.builder()
-                .recentMeetings(recentMeetings)
-                .topAffiliates(topAffiliates)
-                .powerUsers(topPowerUsers)
-                .build();
     }
 }

--- a/src/main/java/com/chungnamthon/cheonon/poweruser/domain/PowerUser.java
+++ b/src/main/java/com/chungnamthon/cheonon/poweruser/domain/PowerUser.java
@@ -27,7 +27,7 @@ public class PowerUser extends BaseEntity {
     private LocalDate weekOf; // 예: 2025-07-22 기준이면 7월 22일 포함된 주의 월요일
 
     @Builder
-    public PowerUser(User user, Integer totalPoint, Integer rank, LocalDate weekOf) {
+    public PowerUser(User user, Integer totalPoint, Integer ranking, LocalDate weekOf) {
         this.user = user;
         this.totalPoint = totalPoint;
         this.ranking = ranking;


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #116 
---
### 📌 요약
- 예외 처리부분 공통 포멧에 맞게 수정 및 예외처리 강화

### ✅ 작업 내용
- BusinessException 기반 예외 처리로 통일
- AuthenticationError enum 추가 및 상세 코드 분리
  - INVALID_REFRESH_TOKEN, KAKAO_EMAIL_NOT_PROVIDED 등
- JwtUtil 내부 검증 로직 전처리/trim 강화 및 검증 실패 로깅 개선
- JwtFilter에서 인증 실패 시 SecurityContext 설정 생략 + WARN 로그 출력
- KakaoOauthService에서 API 실패 시 명확한 예외 코드로 반환
- 전체 인증 흐름의 예외 처리 일관성 및 보안/UX 개선

### 📚 참고 자료, 할 말
- 연동중 문제가 생기면 언제든지 연락 주세요
