### PR TITLE
[FIX] 모임 가입 신청 오류 해결

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/global/exception/error/MeetingError.java
+++ b/src/main/java/com/chungnamthon/cheonon/global/exception/error/MeetingError.java
@@ -16,6 +16,7 @@ public enum MeetingError implements BaseError {
     FORBIDDEN_MEETING_DELETE(HttpStatus.FORBIDDEN, "본인의 모임 게시글만 삭제할 수 있습니다."),
     FORBIDDEN_MEETING_MEMBER_ACCESS(HttpStatus.FORBIDDEN, "본인이 생성한 모임의 멤버 리스트만 조회할 수 있습니다."),
     ALREADY_JOINED_MEETING(HttpStatus.CONFLICT, "이미 참여하고 있는 모임입니다."),
+    ALREADY_REQUESTED_MEETING(HttpStatus.CONFLICT, "이미 신청한 모임입니다."),
     KICKED_USER_CANNOT_REJOIN(HttpStatus.FORBIDDEN, "강퇴당한 모임에는 다시 참여할 수 없습니다."),
     INVALID_JOIN_REQUEST_STATE(HttpStatus.BAD_REQUEST, "이미 참여 중이거나, 신청하지 않은 모임입니다."),
     NOT_JOINED_MEETING(HttpStatus.FORBIDDEN, "참여하고 있지 않은 모임입니다."),

--- a/src/main/java/com/chungnamthon/cheonon/meeting/service/MeetingService.java
+++ b/src/main/java/com/chungnamthon/cheonon/meeting/service/MeetingService.java
@@ -97,6 +97,8 @@ public class MeetingService {
                 throw new BusinessException(MeetingError.ALREADY_JOINED_MEETING);
             } else if (meetingUser.getStatus().equals(Status.KICKED)) {
                 throw new BusinessException(MeetingError.KICKED_USER_CANNOT_REJOIN);
+            } else if (meetingUser.getStatus().equals(Status.REQUESTED)) {
+                throw new BusinessException(MeetingError.ALREADY_REQUESTED_MEETING);
             }
         }
 


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #126 
---
### 📌 요약
- 모임 가입 신청을 했을 때 이미 신청한 모임에 또 신청 하지 못하게 예외처리

### ✅ 작업 내용
- MeetingError 코드 추가
- MeetingService 예외처리 로직 구현

### 📚 참고 자료, 할 말
- 
