### PR TITLE
[REFACTOR] 가맹점 조회 서비스 로직 개선

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/local_merchant/repository/MerchantRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/local_merchant/repository/MerchantRepository.java
@@ -33,11 +33,12 @@ public interface MerchantRepository extends JpaRepository<Merchant, Long> {
          WHERE m.latitude  BETWEEN :southLat AND :northLat
            AND m.longitude BETWEEN :westLng  AND :eastLng
         """)
-    List<Merchant> findMerchantsInBounds(
+    Page<Merchant> findMerchantsInBounds(
             @Param("southLat") Double southLat,
             @Param("northLat") Double northLat,
             @Param("westLng")  Double westLng,
-            @Param("eastLng")  Double eastLng
+            @Param("eastLng")  Double eastLng,
+            Pageable pageable
     );
 
     //name 이 keyword 와 대소문자 구분 없이 정확히 일치하는 Merchant만 페이징 조회

--- a/src/main/java/com/chungnamthon/cheonon/local_merchant/service/MerchantService.java
+++ b/src/main/java/com/chungnamthon/cheonon/local_merchant/service/MerchantService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -126,8 +127,11 @@ public class MerchantService {
             Double swLat, Double swLng,
             Double neLat, Double neLng) {
 
+        // 0페이지(인덱스), 최대 50개
+        Pageable limit50 = PageRequest.of(0, 50);
         return merchantRepository
-                .findMerchantsInBounds(swLat, neLat, swLng, neLng)
+                .findMerchantsInBounds(swLat, neLat, swLng, neLng, limit50)
+                .getContent()
                 .stream()
                 .map(MerchantDto::fromEntity)
                 .collect(toList());


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #128 
---
### 📌 요약
- 페이징을 통해 최대 50개까지만 가능하게 로직 개선

### ✅ 작업 내용
- MerchantRepository 페이징 추가
- MerchantService 페이징 최대 50개까지 가능한 로직 구현

### 📚 참고 자료, 할 말
-
