### PR TITLE
[FEATURE] 파워유저 선정 로직 정량 기준 기반으로 개선

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/meeting/repository/MeetingUserRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/meeting/repository/MeetingUserRepository.java
@@ -4,7 +4,10 @@ import com.chungnamthon.cheonon.meeting.domain.Meeting;
 import com.chungnamthon.cheonon.meeting.domain.MeetingUser;
 import com.chungnamthon.cheonon.meeting.domain.value.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface MeetingUserRepository extends JpaRepository<MeetingUser, Long> {
@@ -15,4 +18,9 @@ public interface MeetingUserRepository extends JpaRepository<MeetingUser, Long> 
     List<MeetingUser> findByUserIdAndStatusIn(Long userId, List<Status> statuses);
 
     List<MeetingUser> findByUserIdAndStatus(Long userId, Status status);
+
+    @Query("SELECT COUNT(mu) FROM MeetingUser mu WHERE mu.user.id = :userId AND mu.createdAt BETWEEN :start AND :end")
+    int countMeetingParticipationByUserIdAndPeriod(@Param("userId") Long userId,
+                                                   @Param("start") LocalDateTime start,
+                                                   @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/chungnamthon/cheonon/point/repository/PointRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/point/repository/PointRepository.java
@@ -32,4 +32,9 @@ public interface PointRepository extends JpaRepository<Point, Long> {
     List<Point> findByUserIdOrderByCreatedAtDesc(Long userId);
 
     boolean existsByUserIdAndPaymentTypeAndCreatedAtBetween(Long userId, PaymentType paymentType, LocalDateTime checkStart, LocalDateTime checkEnd);
+
+    @Query("SELECT COALESCE(SUM(p.changedPoint), 0) FROM Point p WHERE p.user.id = :userId AND p.createdAt BETWEEN :start AND :end")
+    int sumPointByUserIdAndPeriod(@Param("userId") Long userId,
+                                  @Param("start") LocalDateTime start,
+                                  @Param("end") LocalDateTime end);
 }

--- a/src/main/java/com/chungnamthon/cheonon/poweruser/service/PowerUserService.java
+++ b/src/main/java/com/chungnamthon/cheonon/poweruser/service/PowerUserService.java
@@ -2,20 +2,23 @@ package com.chungnamthon.cheonon.poweruser.service;
 
 import com.chungnamthon.cheonon.global.exception.BusinessException;
 import com.chungnamthon.cheonon.global.exception.error.PowerUserError;
+import com.chungnamthon.cheonon.meeting.repository.MeetingUserRepository;
 import com.chungnamthon.cheonon.point.repository.PointRepository;
 import com.chungnamthon.cheonon.poweruser.PowerUserRepository;
 import com.chungnamthon.cheonon.poweruser.domain.PowerUser;
 import com.chungnamthon.cheonon.poweruser.dto.PowerUserResponse;
+import com.chungnamthon.cheonon.receipt_ocr.repository.ReceiptRepository;
 import com.chungnamthon.cheonon.user.domain.User;
 import com.chungnamthon.cheonon.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.*;
 
 @Service
@@ -26,6 +29,8 @@ public class PowerUserService {
     private final PointRepository pointRepository;
     private final PowerUserRepository powerUserRepository;
     private final UserRepository userRepository;
+    private final ReceiptRepository receiptRepository;
+    private final MeetingUserRepository meetingUserRepository;
 
     /**
      * 매주 월요일마다 파워유저 선정 및 저장
@@ -33,29 +38,40 @@ public class PowerUserService {
     @Transactional
     public void updateWeeklyTopUsers() {
         LocalDate thisWeekMonday = LocalDate.now().with(DayOfWeek.MONDAY);
+        LocalDateTime weekStart = thisWeekMonday.atStartOfDay();
+        LocalDateTime weekEnd = thisWeekMonday.plusDays(6).atTime(LocalTime.MAX);
 
-        List<Object[]> topUsers = pointRepository.findTopUsersByTotalPoint(PageRequest.of(0, 5));
-        Set<Long> seenUserIds = new HashSet<>();
+        List<User> users = userRepository.findAll();
+        List<UserScore> scores = new ArrayList<>();
+
+        for (User user : users) {
+            Long userId = user.getId();
+
+            int receiptCount = receiptRepository.countReceiptByUserIdAndPeriod(userId, weekStart, weekEnd);
+            int meetingCount = meetingUserRepository.countMeetingParticipationByUserIdAndPeriod(userId, weekStart, weekEnd);
+            int thisWeekPoint = pointRepository.sumPointByUserIdAndPeriod(userId, weekStart, weekEnd);
+            int totalPoint = pointRepository.sumPointByUserId(userId); // 누적 포인트
+
+            // 기본 점수 계산
+            double baseScore = (receiptCount * 10.0) + (meetingCount * 10.0) + (thisWeekPoint * 0.6);
+
+            // 최종 점수 계산
+            double finalScore = (baseScore * 0.8) + (totalPoint * 0.2);
+
+            scores.add(new UserScore(user, finalScore));
+        }
+
+        scores.sort(Comparator.comparingDouble(UserScore::score).reversed());
+
         int rank = 1;
-
-        for (Object[] row : topUsers) {
-            try {
-                Long userId = (Long) row[0];
-                if (!seenUserIds.add(userId)) continue;
-
-                Integer totalPoint = ((Number) row[1]).intValue();
-
-                User user = userRepository.findById(userId)
-                        .orElseThrow(() -> new BusinessException(PowerUserError.USER_NOT_FOUND));
-
-                PowerUser powerUser = new PowerUser(user, totalPoint, rank++, thisWeekMonday);
-                powerUserRepository.save(powerUser);
-
-            } catch (BusinessException be) {
-                log.warn("파워 유저 저장 실패 (도메인 예외): {}", be.getMessage());
-            } catch (Exception e) {
-                log.error("파워 유저 저장 중 예기치 못한 오류: {}", row[0], e);
-            }
+        for (UserScore userScore : scores.subList(0, Math.min(scores.size(), 5))) {
+            PowerUser powerUser = PowerUser.builder()
+                    .user(userScore.user())
+                    .totalPoint((int) userScore.score())
+                    .ranking(rank++)
+                    .weekOf(thisWeekMonday)
+                    .build();
+            powerUserRepository.save(powerUser);
         }
     }
 
@@ -76,4 +92,6 @@ public class PowerUserService {
                 .map(PowerUserResponse::from)
                 .toList();
     }
+
+    private record UserScore(User user, double score) {}
 }

--- a/src/main/java/com/chungnamthon/cheonon/receipt_ocr/repository/ReceiptRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/receipt_ocr/repository/ReceiptRepository.java
@@ -32,4 +32,9 @@ public interface ReceiptRepository extends JpaRepository<Receipt, Long> {
     boolean existsByPreview(ReceiptPreview preview);
 
     List<Receipt> findByMerchantAndCreatedAtAfter(Merchant merchant, LocalDateTime thirtyMinutesAgo);
+
+    @Query("SELECT COUNT(r) FROM Receipt r WHERE r.user.id = :userId AND r.createdAt BETWEEN :start AND :end")
+    int countReceiptByUserIdAndPeriod(@Param("userId") Long userId,
+                                      @Param("start") LocalDateTime start,
+                                      @Param("end") LocalDateTime end);
 }


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #130 
---
### 📌 요약
-영수증 인증 수, 모임 참여 수, 이번 주 포인트를 가중치 기반으로 점수화 · 기본 점수 = (영수증×10 + 모임×10 + 이번주포인트×0.6) · 최종 점수 = (기본 점수×0.8 + 누적 포인트×0.2)

### ✅ 작업 내용
- 영수증 인증 수, 모임 참여 수, 이번 주 포인트를 가중치 기반으로 점수화 · 기본 점수 = (영수증×10 + 모임×10 + 이번주포인트×0.6) · 최종 점수 = (기본 점수×0.8 + 누적 포인트×0.2)

- PowerUserService 리팩토링: 기존 포인트 랭킹 방식 제거 → 전체 유저 점수 직접 계산 방식으로 변경
- receiptRepository, meetingUserRepository 등 정량 집계를 위한 의존성 추가
- 불필요한 중복 유저 제거 및 전체 유저 대상 점수 계산 처리


### 📚 참고 자료, 할 말
- 연동중 문제가 생기면 연락 주세요
