### PR TITLE
[REFACTOR] 포인트 적립 정책 전면 개편 및 적용

### DIFF
--- a/src/main/java/com/chungnamthon/cheonon/point/domain/value/PaymentType.java
+++ b/src/main/java/com/chungnamthon/cheonon/point/domain/value/PaymentType.java
@@ -6,5 +6,6 @@ public enum PaymentType {
     PAYMENT_VERIFICATION, // 천안사랑카드 결제 인증
     PARTNER_STORE_BONUS, // 제휴 상권 이용 보너스
     WEEKLY_STREAK_BONUS, // 연속 참여 보너스
-    EXCHANGE_COUPON // 쿠폰 교환
+    EXCHANGE_COUPON, // 쿠폰 교환
+    SIGN_UP;
 }

--- a/src/main/java/com/chungnamthon/cheonon/point/repository/PointRepository.java
+++ b/src/main/java/com/chungnamthon/cheonon/point/repository/PointRepository.java
@@ -37,4 +37,6 @@ public interface PointRepository extends JpaRepository<Point, Long> {
     int sumPointByUserIdAndPeriod(@Param("userId") Long userId,
                                   @Param("start") LocalDateTime start,
                                   @Param("end") LocalDateTime end);
+    List<Point> findByUserIdAndPaymentTypeAndCreatedAtBetween(
+            Long userId, PaymentType type, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/chungnamthon/cheonon/receipt_ocr/service/ReceiptService.java
+++ b/src/main/java/com/chungnamthon/cheonon/receipt_ocr/service/ReceiptService.java
@@ -186,7 +186,10 @@ public class ReceiptService {
                             recentReceipt.getMerchant().getId(), recentReceipt.getCreatedAt());
 
                     if (!alreadyRewarded) {
-                        pointService.rewardForAffiliateStoreProof(recentReceipt.getUser().getId());
+                        pointService.rewardForReceiptVerification(
+                                recentReceipt.getUser().getId(),
+                                recentReceipt.getMerchant().getIsAffiliate()
+                        );
                         log.info("사용자 {}에게 팀 인증 포인트 지급 완료", recentReceipt.getUser().getId());
                     } else {
                         log.info("사용자 {}는 이미 포인트를 받았습니다", recentReceipt.getUser().getId());
@@ -219,7 +222,10 @@ public class ReceiptService {
         LocalDateTime checkEnd = receiptCreatedAt.plusMinutes(30);
 
         return pointRepo.existsByUserIdAndPaymentTypeAndCreatedAtBetween(
-                userId, PaymentType.PAYMENT_VERIFICATION, checkStart, checkEnd);
+                userId, PaymentType.PAYMENT_VERIFICATION, checkStart, checkEnd
+        ) || pointRepo.existsByUserIdAndPaymentTypeAndCreatedAtBetween(
+                userId, PaymentType.PARTNER_STORE_BONUS, checkStart, checkEnd
+        );
     }
 
     // 거리 계산


### PR DESCRIPTION
<!-- #이슈 번호를 매겨주세요 -->
- resolves #141 
---
### 📌 요약
- 포인트 적립 정책 전면 개편

### ✅ 작업 내용
- 회원가입 시 최초 1회 1000포인트 지급 (`SIGN_UP`)
- 영수증 인증 시 일반 100p / 제휴 가맹점 200p 지급
  - 주간 인증 최대 5회로 제한
  - 30분 이내 동일 가맹점 중복 인증 방지 로직 개선
- 모임 생성 시 주 1회 70p 지급
- 모임 참여(승인 시) 주 3회 50p 지급
- 연속 참여 보너스 로직용 메서드 (`rewardForWeeklyStreakParticipation`) 유지
- `PaymentType` Enum에 정책에 맞는 타입 정리 및 추가
- `PointService` 전면 리팩토링: `isOverWeeklyLimit()`, `reward()` 기반으로 중복 제거
- `MeetingService`, `ReceiptService`, `KakaoOauthService`에 포인트 지급 연결 완료

### 📚 참고 자료, 할 말
- 연동중 문제가 생기면 연락주세요!!
